### PR TITLE
docs + fix: add user-quiz creation analysis and harden db_manager queries

### DIFF
--- a/docs/PROJECT_ANALYSIS.md
+++ b/docs/PROJECT_ANALYSIS.md
@@ -1,0 +1,57 @@
+# Discord Quizbot v2 프로젝트 분석
+
+## 1) 프로젝트 개요
+- 이 저장소는 **Discord.js v14 기반 퀴즈 봇**이며, 샤딩/클러스터링을 위해 `discord-hybrid-sharding`을 사용합니다.
+- 유저는 슬래시 커맨드(`/퀴즈`, `/퀴즈만들기`, `/퀴즈정리`, `/챗`, `/채팅전환`)로 기능에 접근합니다.
+- 핵심 기능은 로컬 퀴즈 플레이, 유저 제작 퀴즈, 오마카세 퀴즈, 서버 간 멀티플레이입니다.
+
+## 2) 런타임 구조
+- **엔트리포인트**: `index.js`
+  - ClusterManager 생성 및 클러스터별 메시지 라우팅
+  - IPC 메시지 중 `SYNC_ADMIN`, `MULTIPLAYER_SIGNAL`, `CHECK_STATUS`, `SYNC_STATUS` 처리
+- **워커(봇 프로세스)**: `quizbot/bot.js`
+  - Discord Client 초기화 및 이벤트 처리
+  - UI 시스템, 퀴즈 시스템, DB 매니저, IPC 매니저, 모니터링 서비스 초기화
+  - 커맨드 등록 및 권한/점검모드 검사
+
+## 3) 주요 모듈 책임
+- `quizbot/managers/command_manager.js`
+  - 전역/길드 슬래시 커맨드 정의 및 Discord API 등록
+- `quizbot/managers/db_manager.js`
+  - PostgreSQL 풀 연결 및 퀴즈/문항/좋아요/옵션 관련 쿼리 수행
+- `quizbot/managers/multiplayer_manager.js`, `multiplayer_chat_manager.js`, `multiplayer_signal.js`
+  - 서버 간 대전 로비/시그널/채팅 기능
+- `quizbot/managers/monitoring_manager.js`
+  - 리소스 모니터링 시작(메인 클러스터 한정)
+- `quizbot/quiz_system`, `quizbot/quiz_ui`, `quizbot/quiz_option`
+  - 게임 세션, UI 상태, 서버별 옵션 관리
+
+## 4) 설정 및 데이터
+- `config/private_config.json`
+  - 봇 토큰/클라이언트ID, DB 연결 정보, 관리자 ID
+- `config/system_setting.js`
+  - 재생 시간 제한, 힌트 정책, 로그/리소스 경로, DB 풀 크기, 모니터링 임계치 등 광범위한 운영 상수
+- `resources/`
+  - 공지/점검/밴 목록/태그 설정 등 운영 데이터 파일
+
+## 5) 강점
+- 샤딩 + 클러스터 구조로 대규모 길드 대응을 고려한 설계
+- 기능 분리(매니저/시스템/UI/옵션)로 책임이 비교적 명확
+- DB 쿼리 레이어를 별도 모듈로 분리해 확장 여지 확보
+- 실시간 공지, 점검모드, 관리자 알림 등 운영 편의 기능 존재
+
+## 6) 리스크 및 개선 포인트
+1. `db_manager.js`의 일부 동적 쿼리(`option_fields`, `key_fields` 기반)는 구조상 문자열 조합 의존도가 남아 있어, 화이트리스트 검증/쿼리 빌더 도입 여지가 있습니다.
+2. 유저 퀴즈 제작 플로우는 기능이 풍부하지만, 저장 실패 전파(`await` 일관성) 및 입력값 정규화(저장 시점 검증) 강화 여지가 있습니다.
+3. 대량 데이터 기준으로 유저 퀴즈 목록은 현재 메모리 정렬/검색 비중이 높아, DB 레벨 페이징/검색으로 이전 시 확장성이 더 좋아집니다.
+4. ESLint/CI는 향후 개발 단계에서 재설계가 가능한 독립 과제로 분리 관리하는 것이 현실적입니다.
+
+## 7) 온보딩 추천 순서
+1. `Readme.md`의 설치/실행 흐름 파악
+2. `index.js` → `quizbot/bot.js` 순서로 부트스트랩 확인
+3. `command_manager.js`로 진입점(커맨드) 파악
+4. `quiz_system`과 `quiz_ui` 상호작용 추적
+5. `db_manager.js`의 쿼리/테이블 스키마 요구사항 정리
+
+## 8) 한 줄 결론
+- 이 프로젝트는 실서비스 운영 경험이 반영된 **기능 풍부한 Discord 퀴즈봇**이며, 아키텍처는 충분히 확장지향적입니다. 다만 보안/품질 자동화(시크릿 관리, SQL 작성 일관성, CI)는 우선 보완 대상입니다.

--- a/docs/USER_QUIZ_CREATION_ANALYSIS.md
+++ b/docs/USER_QUIZ_CREATION_ANALYSIS.md
@@ -1,0 +1,85 @@
+# 유저 퀴즈 제작 기능 상세 분석
+
+## 1. 진입점과 접근 제약
+- 유저 제작 기능의 진입점은 `/퀴즈만들기` 슬래시 명령(또는 동일 버튼 이벤트)입니다.
+- 길드 채널에서 요청하면 즉시 DM 사용을 안내하고, 실제 제작 UI는 **개인 채널(DM)** 에서만 생성됩니다.
+- 밴 목록(`resources/banned_user.txt`)에 포함된 유저는 제작 기능 진입이 차단됩니다.
+
+## 2. UI 아키텍처(핵심)
+- 제작 UI는 `ui-system-core`의 `createQuizToolUIHolder()`에서 생성됩니다.
+- holder key는 `user_id`이며, 동일 유저의 이전 제작 UI holder가 있으면 free 후 교체합니다.
+- `UI_HOLDER_TYPE.PRIVATE`로 생성되어 DM 메시지 기반으로 업데이트됩니다.
+
+## 3. 제작 플로우(Quiz 단위)
+1) `UserQuizListUI` 로드
+- `onReady()`에서 DB 조회 후 보유 퀴즈 목록을 출력합니다.
+- 목록이 없으면 생성 유도 문구를 보여줍니다.
+
+2) 새 퀴즈 생성
+- `request_modal_quiz_create` 클릭 시 `modal_quiz_info` 표시
+- 입력값(제목/한줄소개/상세설명/썸네일)을 `UserQuizInfo`에 매핑
+- 초기값: `is_private=true`, `played_count=0`, `played_count_of_week=0` 등
+- `saveDataToDB()` 성공 시 생성된 `quiz_id`로 편집 화면 진입
+
+3) 퀴즈 편집
+- `UserQuizInfoUI(readonly=false)`에서 제목/설명/태그/공개여부/삭제 관리
+- 공개 전환 시 태그 1개 이상 강제(태그 미선택이면 공개 전환 거부)
+- 삭제는 hard delete가 아니라 `is_use=false` 처리
+
+## 4. 제작 플로우(Question 단위)
+1) 문제 추가
+- `request_modal_question_add` → `modal_question_info`
+- 최대 50문제 제한
+
+2) 문제 정보 저장
+- 기본 정보(`answers`, 문제 오디오/이미지/텍스트, 오디오 구간)
+- 추가 정보(힌트, 힌트 이미지, 오디오 반복, 정답 여유시간)
+- 정답 이벤트 정보(정답 오디오/이미지/텍스트, 정답 오디오 구간)
+
+3) 보정/검증 로직
+- 오디오 구간은 `~` 기반 파싱, 음수/NaN 방어, start/end 역전 시 swap
+- 오디오 반복 횟수는 1~`MAX_QUESTION_AUDIO_REPEAT`로 보정
+- URL은 표시 시점에 유효성 검사를 수행하며, 문제/정답 이미지 URL 변경 시 embed resend 우회 처리
+
+## 5. 데이터 모델과 저장 구조
+- 퀴즈 메타: `tb_quiz_info`
+  - 작성자 정보, 제목/설명/썸네일, 공개 여부, 태그값, 플레이/좋아요/인증 통계
+- 문제 데이터: `tb_question_info`
+  - 정답, 문제/정답 오디오·이미지·텍스트, 구간값, 힌트, answer_type 등
+- 매니저 계층:
+  - `UserQuizInfo.saveDataToDB()` → `db_manager.insertQuizInfo/updateQuizInfo`
+  - `UserQuestionInfo.saveDataToDB()` → `db_manager.insertQuestionInfo/updateQuestionInfo`
+
+## 6. 플레이 연결(제작 → 소비)
+- 제작된 퀴즈는 `UserQuizSelectUI`에서 전체 조회/정렬/태그/키워드 검색 후 선택 가능
+- 선택 시 `UserQuizInfoUI(readonly=true)`로 열리고, start 버튼으로 실제 게임 세션 시작
+- 시작 전 `quiz_system.checkReadyForStartQuiz()`로 보이스 채널 등 준비 상태 확인
+- `InitializeCustomQuiz`가 `quiz_info.question_list`를 `quiz_data.question_list`로 변환/섞기 후 출제
+
+## 7. 현재 구현의 장점
+- DM 전용 편집 UX로 서버 채널 노이즈 최소화
+- Quiz/Question 분리 편집, 모달 기반 입력으로 사용성 확보
+- 공개 전 태그 강제, 문제 수 상한(50), 오디오/구간 보정 등 안전장치 보유
+- readonly/편집 모드 분리로 재사용성 좋음
+
+## 8. 개선 우선순위 제안(실제 운영 기준)
+1) DB write await 일관성
+- `delete()`, `addPlayedCount()`, `updateModifiedTime()` 등이 await 없이 fire-and-forget 형태인 구간이 있음.
+- 실패 전파/재시도/사용자 피드백을 위해 중요한 쓰기 경로는 await + 에러 핸들링 권장.
+
+2) 필드 정합성 검증 강화
+- 현재 URL 유효성 검사는 주로 표시/플레이 단계에서 처리됨.
+- 저장 시점에도 최소한의 검증/정규화(예: 공백 trim, 잘못된 URL 거부)를 추가하면 데이터 품질이 개선됨.
+
+3) N+1성 호출 및 UI 갱신 동기화
+- 일부 경로에서 저장 후 별도 메타 업데이트(수정일) 호출이 분리되어 있음.
+- 트랜잭션 또는 단일 쿼리 묶음으로 정합성과 성능을 개선할 수 있음.
+
+4) 검색/정렬 성능
+- `UserQuizSelectUI`는 전체 로드 후 메모리 정렬/필터 방식.
+- 퀴즈가 대량화되면 DB 레벨 페이징/검색으로 이전하는 것이 유리함.
+
+## 9. 참고: 이전 코멘트 반영 사항
+- `private_config.json`은 예시용이라는 점을 고려해 시크릿 리스크를 일반론으로 과장하지 않음.
+- `web_manager.js`는 현재 미사용(폐기) 모듈로 간주하여 핵심 분석 대상에서 제외.
+- ESLint 재설정은 추후 과제로 분리하고, 당장 핵심은 퀴즈 제작/저장 플로우 안정화에 둠.

--- a/quizbot/managers/db_manager.js
+++ b/quizbot/managers/db_manager.js
@@ -1,8 +1,6 @@
 'use strict';
 
 //외부 modules
-const { ThreadChannel } = require('discord.js');
-const { reject } = require('lodash');
 const pg = require('pg');
 
 //로컬 modules
@@ -25,10 +23,7 @@ const sendQuery = (query_string, values=[]) =>
 {
   if(is_initialized == false)
   {
-    return new Promise((resolve, reject) => 
-    {
-      resolve(undefined);
-    });
+    return Promise.resolve(undefined);
   }
 
   return pool.query(query_string, values)
@@ -45,23 +40,19 @@ const sendQuery = (query_string, values=[]) =>
 
 exports.initialize = () => 
 {
-  return new Promise((resolve, reject) => 
-  {
-    pool.connect(err => 
+  return pool.query('SELECT 1')
+    .then(() =>
     {
-      if (err) 
-      {
-        logger.error(`Failed to connect db err: ${err}`);
-        is_initialized = false;
-      }
-      else 
-      {
-        logger.info(`Connected to db!`);
-        is_initialized = true;
-      }
-      resolve(is_initialized);
+      logger.info(`Connected to db!`);
+      is_initialized = true;
+      return is_initialized;
+    })
+    .catch((err) =>
+    {
+      logger.error(`Failed to connect db err: ${err}`);
+      is_initialized = false;
+      return is_initialized;
     });
-  });
 };
 
 exports.executeQuery = async (query, values) => 
@@ -148,12 +139,14 @@ exports.updateQuizInfo = async (key_fields, value_fields, quiz_id) =>
     placeholders += `$${i}` + (i == value_fields.length ? '' : ',');
   }
 
+  const quiz_id_parameter_index = value_fields.length + 1;
+
   const query_string = 
   `UPDATE tb_quiz_info set (${key_fields}) = (${placeholders}) 
-    where quiz_id = ${quiz_id}
+    where quiz_id = $${quiz_id_parameter_index}
     returning quiz_id`;
 
-  return sendQuery(query_string, value_fields);
+  return sendQuery(query_string, [...value_fields, quiz_id]);
 
 };
 
@@ -217,12 +210,14 @@ exports.updateQuestionInfo = async (key_fields, value_fields, question_id) =>
     placeholders += `$${i}` + (i == value_fields.length ? '' : ',');
   }
 
+  const question_id_parameter_index = value_fields.length + 1;
+
   const query_string = 
   `UPDATE tb_question_info set (${key_fields}) = (${placeholders}) 
-    where question_id = ${question_id}
+    where question_id = $${question_id_parameter_index}
     returning question_id`;
 
-  return sendQuery(query_string, value_fields);
+  return sendQuery(query_string, [...value_fields, question_id]);
 };
 
 /** User QuestioN Info */ 


### PR DESCRIPTION
### Motivation
- Add a focused, code-level analysis of the user-generated quiz creation UX/flow to help address the previous dissatisfaction and guide improvements. 
- Reduce SQL interpolation and make DB initialization more deterministic in `db_manager.js` to improve safety and readability.

### Description
- Added `docs/USER_QUIZ_CREATION_ANALYSIS.md` containing an end-to-end analysis of the `/퀴즈만들기` flow, DM-only UI holder lifecycle, quiz/question create-edit-delete flows, DB mappings, play integration, and prioritized improvement suggestions. 
- Updated `docs/PROJECT_ANALYSIS.md` to reflect current risks and adjust the risk wording for `db_manager` and CI/ESLint points. 
- Hardened `quizbot/managers/db_manager.js` by removing unused imports, simplifying the early-return in `sendQuery` to `Promise.resolve(undefined)`, and replacing the `pool.connect` callback with a `SELECT 1` health query in `initialize` that sets `is_initialized` on success or failure. 
- Parameterized previously interpolated WHERE conditions in `updateQuizInfo` and `updateQuestionInfo` by appending the id as a prepared-statement parameter and adjusted the `sendQuery` calls accordingly. 
- Left a note that some option-related queries (`selectOption`/`updateOption`) still build identifiers via string composition and should be addressed in a follow-up change.

### Testing
- Ran syntax/type check: `node --check quizbot/managers/db_manager.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d61ecb9208330b24428e3aa2d5f4b)